### PR TITLE
Initial code to support running comprehensive unit and regression tests

### DIFF
--- a/packages_dir/Ska.Numpy/test_unit_git.sh
+++ b/packages_dir/Ska.Numpy/test_unit_git.sh
@@ -1,0 +1,6 @@
+SOT_REPO='git@github.com:/sot'
+git clone ${SOT_REPO}/Ska.Numpy
+cd Ska.Numpy
+git checkout master
+python setup.py build_ext --inplace
+py.test test.py -v

--- a/packages_dir/chandra_aca/test_unit.py
+++ b/packages_dir/chandra_aca/test_unit.py
@@ -1,0 +1,2 @@
+import ska_test
+ska_test.test("-v", package_from_dir=True, raise_exception=True)

--- a/packages_dir/dpa_check/test_regress_feb0413a.sh
+++ b/packages_dir/dpa_check/test_regress_feb0413a.sh
@@ -1,0 +1,4 @@
+python /proj/sot/ska/share/dpa/dpa_check.py \
+   --outdir=feb0413a \
+   --oflsdir=/data/mpcrit1/mplogs/2013/FEB0413/oflsa \
+   --run-start=2013:031

--- a/packages_dir/xija/test_unit.py
+++ b/packages_dir/xija/test_unit.py
@@ -1,0 +1,4 @@
+import xija
+n_fail = xija.test('-v', '-k test_data_types')
+if n_fail > 0:
+    raise ValueError(str(n_fail) + ' test failures')

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,172 @@
+#! /usr/bin/env python
+
+from __future__ import print_function, absolute_import, division
+
+from glob import glob
+from fnmatch import fnmatch
+import sys
+import os
+import shutil
+
+import Ska.File
+from Chandra.Time import DateTime
+from Ska.Shell import bash, ShellError
+from pyyaks.logger import get_logger
+from astropy.table import Table
+
+opt = None
+logger = get_logger(name='run_tests')
+
+
+def get_options():
+    """Get options.
+    Output: optionns"""
+    from optparse import OptionParser
+    parser = OptionParser()
+    parser.set_defaults()
+
+    parser.add_option("--packages-dir",
+                      default="packages_dir",
+                      help="Directory containing package tests",
+                      )
+    parser.add_option("--outputs-dir",
+                      default="outputs_dir",
+                      help="Root directory containing all output package test runs",
+                      )
+    parser.add_option("--outputs-subdir",
+                      help="Directory containing per-run output package test runs",
+                      )
+    parser.add_option("--include",
+                      default='*',
+                      help=("Include tests that match comma-separated "
+                            "list of glob pattern(s) (default='*')"),
+                      )
+    parser.add_option("--exclude",
+                      default='*_long',
+                      help=("Exclude tests that match comma-separated "
+                            "list of glob pattern(s) (default='*_long')"),
+                      )
+    return parser.parse_args()[0]
+
+
+class Tee(object):
+    def __init__(self, name, mode='w'):
+        self.fh = open(name, mode)
+
+    def __del__(self):
+        self.fh.close()
+
+    def write(self, data):
+        self.fh.write(data)
+        sys.stdout.write(data)
+
+    def flush(self):
+        self.fh.flush()
+        sys.stdout.flush()
+
+
+def box_output(lines, min_width=40):
+    width = max(min_width, 8 + max([len(x) for x in lines]))
+    logger.info('*' * width)
+    fmt = '*** {:' + str(width - 8) + 's} ***'
+    for line in lines:
+        logger.info(fmt.format(line))
+    logger.info('*' * width)
+    logger.info('')
+
+
+def get_packages():
+    with Ska.File.chdir(opt.packages_dir):
+        packages = [x for x in os.listdir('.') if os.path.isdir(x)]
+    return packages
+
+
+def include_test_file(package, test_file):
+    path = os.path.join(package, test_file)
+    include = any(fnmatch(path, x.strip()) for x in opt.include.split(','))
+    exclude = any(fnmatch(path, x.strip()) for x in opt.exclude.split(','))
+    return include and not exclude
+
+
+def run_tests(package):
+    # Collect test scripts in package and find the ones that are included
+    in_dir = os.path.join(opt.packages_dir, package)
+    with Ska.File.chdir(in_dir):
+        test_files = glob('test*.py') + glob('test*.sh')
+        include_test_files = [x for x in test_files if include_test_file(package, x)]
+        print(package, test_files, include_test_files)
+
+    skipping = '' if include_test_files else ': skipping - no included tests'
+    box_output(['package {}{}'.format(package, skipping)])
+
+    # If no included tests then print message and bail out
+    if not include_test_files:
+        logger.info('')
+        return []
+
+    # Make the output directory
+    out_dir = os.path.join(opt.outputs_dir, opt.outputs_subdir, package)
+    if os.path.exists(out_dir):
+        raise IOError('output dir {} already exists'.format(out_dir))
+
+    # Copy all files.  Excluded test scripts will be removed later.
+    logger.info('Copying input tests {} to output dir {}'.format(in_dir, out_dir))
+    shutil.copytree(in_dir, out_dir, symlinks=True, ignore=shutil.ignore_patterns('*~'))
+
+    # Make a symlink 'last' to the most recent directory
+    with Ska.File.chdir(opt.outputs_dir):
+        if os.path.exists('last'):
+            os.unlink('last')
+        os.symlink(opt.outputs_subdir, 'last')
+
+    # Now run the tests and collect test status
+    statuses = []
+    with Ska.File.chdir(out_dir):
+        for test_file in test_files:
+            if test_file not in include_test_files:
+                os.unlink(test_file)
+                statuses.append((test_file, 'skip'))
+                continue
+
+            interpreter = 'python' if test_file.endswith('.py') else 'bash'
+
+            logger.info('Running {} {} script'.format(interpreter, test_file))
+            logfile = Tee(test_file + '.log')
+
+            try:
+                bash('{} {}'.format(interpreter, test_file), logfile=logfile)
+            except ShellError:
+                # Test process returned a non-zero status => Fail
+                statuses.append((test_file, 'fail'))
+            else:
+                statuses.append((test_file, 'success'))
+
+    box_output(['{} Test Summary'.format(package)] +
+               ['{:20s} {}'.format(test_file, status) for test_file, status in statuses])
+
+    return statuses
+
+
+def main():
+    global opt
+    opt = get_options()
+
+    # Set up directories
+    if opt.outputs_subdir is None:
+        ska_version = bash('ska_version')[0]
+        opt.outputs_subdir = '{}-{}'.format(DateTime().fits[:19], ska_version)
+
+    os.makedirs(os.path.join(opt.outputs_dir, opt.outputs_subdir))
+
+    results = []
+    packages = get_packages()
+    for package in sorted(packages):
+        statuses = run_tests(package)
+        for test_file, status in statuses:
+            results.append((package, test_file, status))
+
+    results = Table(rows=results, names=('Package', 'Script', 'Status'))
+    box_output(results.pformat())
+
+if __name__ == '__main__':
+    main()

--- a/run_tests.py
+++ b/run_tests.py
@@ -94,7 +94,6 @@ def run_tests(package):
     with Ska.File.chdir(in_dir):
         test_files = glob('test*.py') + glob('test*.sh')
         include_test_files = [x for x in test_files if include_test_file(package, x)]
-        print(package, test_files, include_test_files)
 
     skipping = '' if include_test_files else ': skipping - no included tests'
     box_output(['package {}{}'.format(package, skipping)])

--- a/ska_test/runner.py
+++ b/ska_test/runner.py
@@ -45,12 +45,28 @@ def test(*args, **kwargs):
             os.chdir(curdir)
 
     raise_exception = kwargs.pop('raise_exception', False)
+    package_from_dir = kwargs.pop('package_from_dir', False)
 
     calling_frame_record = inspect.stack()[1]  # Only works for stack-based Python
-    calling_frame = calling_frame_record[0]
     calling_func_file = calling_frame_record[1]
-    calling_func_name = calling_frame_record[3]
-    calling_func_module = calling_frame.f_globals[calling_func_name].__module__
+
+    if package_from_dir:
+        # In this case it is assumed that the module which called this function is
+        # located in a directory named by the package that is to be tested.  I.e.
+        # chandra_aca/test.py.  However, this is NOT the actual package directory
+        # so we have to import the package to get its parent directory.
+        import importlib
+        package = os.path.basename(os.path.dirname(os.path.abspath(calling_func_file)))
+        print('package', package)
+        module = importlib.import_module(package)
+        calling_func_file = module.__file__
+        calling_func_module = module.__name__
+    else:
+        # In this case the module that called this function is the package __init__.py.
+        # We get the module directly without doing another import.
+        calling_frame = calling_frame_record[0]
+        calling_func_name = calling_frame_record[3]
+        calling_func_module = calling_frame.f_globals[calling_func_name].__module__
 
     pkg_names = calling_func_module.split('.')
     pkg_paths = [os.path.dirname(calling_func_file)] + ['..'] * len(pkg_names)


### PR DESCRIPTION
This is an initial demo of the direction for Ska regression and unit testing:
```
# clone repo and get into directory
export PYTHONPATH=$PWD
python run_tests.py
...
ls outputs_dir/
2016-08-26T21:01:50-0.18-r606-3c743e6/  last@
```
An important feature still to be done is adding scripts that clean the build files and other "uninteresting" test output files, leaving only good stuff that can be diffed.  These clean scripts can also do things like filter out time stamps or user names that cause uninteresting diffs.

The existing test cases are in `packages_dir`.  A key feature is that this is basically configuration-free.  You just put files `test*.py` or `test*.sh` in a directory with the package name and that's it.  There will end up being some minimal repetition (e.g. there will be a standard `test_unit.py` that gets repeated, but the `chandra_aca` example shows that this is actually factored out into `ska_test/runner.py`.

I'm going to merge this immediately but am making a PR to enable comments.