### PR TITLE
Add functionality for handling regression output files

### DIFF
--- a/packages_dir/chandra_aca/regress_files.py
+++ b/packages_dir/chandra_aca/regress_files.py
@@ -1,0 +1,11 @@
+from ska_test.runner import make_regress_files
+
+regress_files = ['test_unit.py.log']
+clean = {'test_unit.py.log':
+             [(r'.*\d+ passed.*seconds.*', ''),
+              (r'^platform.+py.+pytest.+', ''),
+              (r'^Bash-\d\d:\d\d:\d\d', 'Bash-HH:MM:SS')]
+         }
+
+make_regress_files(regress_files, clean=clean)
+

--- a/packages_dir/dpa_check/regress_files.py
+++ b/packages_dir/dpa_check/regress_files.py
@@ -1,0 +1,11 @@
+from ska_test.runner import make_regress_files
+
+regress_files = ['out/index.rst',
+                 'out/run.dat',
+                 'out/states.dat',
+                 'out/temperatures.dat']
+
+clean = {'out/index.rst': [(r'^Run time.*', '')],
+         'out/run.dat': [(r'#.*py run at.*', '')]}
+
+make_regress_files(regress_files, clean=clean)

--- a/packages_dir/dpa_check/test_regress.sh
+++ b/packages_dir/dpa_check/test_regress.sh
@@ -1,4 +1,4 @@
 python /proj/sot/ska/share/dpa/dpa_check.py \
-   --outdir=feb0413a \
+   --outdir=out \
    --oflsdir=/data/mpcrit1/mplogs/2013/FEB0413/oflsa \
    --run-start=2013:031


### PR DESCRIPTION
The plan is that a subset of files are copied into a `regress` dir that can be diffed.  There is a built-in mechanism for doing reg-ex substitutions to clean out things like time stamps which will generate spurious diffs.