### PR TITLE
Add interim long regression tests for archive creation

### DIFF
--- a/packages/Ska.engarchive/compare_values.py
+++ b/packages/Ska.engarchive/compare_values.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+"""
+Compare locally generated eng archive data store with flight (/proj/sot/ska)
+values.  This is assumed to be run as part of eng_archive regression testing
+and requires that the local data store is in the current working directory
+as ``data``.
+"""
+
+import os
+
+import numpy as np
+from Ska.engarchive import fetch
+import argparse
+
+
+def get_options(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--start",
+                        help="Start time")
+    parser.add_argument("--stop",
+                        help="Stop time")
+    parser.add_argument("--flight-root",
+                        default='/proj/sot/ska',
+                        help="Flight root directory (default=/proj/sot/ska")
+    parser.add_argument("--content",
+                        action='append',
+                        help="Content type to process")
+    return parser.parse_args(args)
+
+
+def compare_msid(msid, stat):
+    """
+    Compare ``stat`` data for ``msid``: locally generated vs. flight in /proj/sot/ska.
+    """
+    # Start with the local version which is generated over a small slice of time
+    # (a few days).
+    fetch.msid_files.basedir = os.getcwd()
+    local = fetch.Msid(msid, opt.start, opt.stop, stat=stat)
+
+    # Now use definitive Ska flight data as reference for comparison.
+    # Fetch over an interval which is just slightly longer.
+    tstart = local.times[0] - 0.0001
+    tstop = local.times[-1] + 0.0001
+    fetch.msid_files.basedir = os.path.join(opt.flight_root, 'data', 'eng_archive')
+    flight = fetch.Msid(msid, tstart, tstop, stat=stat)
+
+    fails = []
+
+    if len(local) != len(flight):
+        fails.append(' length local:{} flight{}'.format(len(local), len(flight)))
+    else:
+        for colname in local.colnames:
+            local_value = getattr(local, colname)
+            flight_value = getattr(flight, colname)
+
+            # Do not explicitly test bads, this is done implicitly by virtue of
+            # the bad filtering already applied.
+            if colname is 'bads':
+                continue
+
+            # Extend the colname for reporting purposes
+            if stat:
+                colname = colname + '[{}]'.format(stat)
+
+            # Check dtype equality
+            if local_value.dtype != flight_value.dtype:
+                fails.append('.{} dtype local:{} flight{}'
+                             .format(colname, local.dtype, flight.dtype))
+                continue
+
+            # Define comparison operator based on type
+            if local_value.dtype.kind in ('i', 'u', 'S', 'U', 'b'):  # int, str, unicode, bool
+                compare = lambda x, y: np.all(x == y)
+            elif local_value.dtype.kind == 'f':  # float
+                compare = np.allclose
+            else:
+                fails.append('.{} unexpected dtype {}'.format(colname, local_value.dtype))
+                continue
+
+            if not compare(local_value, flight_value):
+                fails.append('.{} local != flight'.format(colname))
+
+    fails = [msid + fail for fail in fails]
+    return fails
+
+
+opt = get_options()
+
+any_fail = False
+
+for content in opt.content:
+    # Get all the MSIDs for this content type
+    msids = [msid for msid, msid_content in fetch.content.items()
+             if content == msid_content]
+
+    for msid in msids:
+        print('{} {}'.format(content, msid))
+        for stat in (None, '5min', 'daily'):
+            fails = compare_msid(msid, stat)
+            if fails:
+                print('\n'.join(fails))
+                any_fail = True
+
+if any_fail:
+    raise RuntimeError('some comparisons failed')

--- a/packages/Ska.engarchive/test_regress_long.sh
+++ b/packages/Ska.engarchive/test_regress_long.sh
@@ -1,0 +1,28 @@
+# Test creating new engineering archive database and compare to flight data
+
+git clone ${PACKAGES_REPO}/eng_archive
+cd eng_archive
+git checkout create-faster
+cp update_archive.py archfiles_def.sql ../
+cd ../
+mkdir data
+
+CONTENTS="--content=acis2eng --content=acis3eng --content=acisdeahk --content=simcoor"
+START="2016:100"
+STOP="2016:105"
+
+# TODO: fix : CONTENTS="--content=orbitephem0"
+
+export ENG_ARCHIVE=$PWD
+export PYTHONPATH=/home/aldcroft/git/eng_archive/local/lib/python2.7/site-packages
+
+echo "Creating archive..."
+./update_archive.py --date-start $START --date-now $STOP --max-lookback-time=2 \
+   --create --data-root=$PWD $CONTENTS
+
+# TODO: add derive parameter --content=dp_acispow128
+
+echo "Creating archive stats..."
+./update_archive.py --no-full $CONTENTS --max-lookback-time 1e20
+
+./compare_values.py --start=$START --stop=$STOP $CONTENTS

--- a/run_tests.py
+++ b/run_tests.py
@@ -92,7 +92,10 @@ def box_output(lines, min_width=40):
 def include_test_file(package, test_file):
     path = os.path.join(package, test_file)
     include = any(fnmatch(path, x.strip() + '*') for x in opt.include.split(','))
-    exclude = any(fnmatch(path, x.strip() + '*') for x in opt.exclude.split(','))
+    if opt.exclude:
+        exclude = any(fnmatch(path, x.strip() + '*') for x in opt.exclude.split(','))
+    else:
+        exclude = False
     return include and not exclude
 
 
@@ -114,7 +117,7 @@ def collect_tests():
         with Ska.File.chdir(in_dir):
             test_files = glob('test*.py') + glob('test*.sh') + glob('copy_regress_files.py')
             for test_file in test_files:
-                status = 'not run' if include_test_file(package, test_file) else 'Skip'
+                status = 'not run' if include_test_file(package, test_file) else '----'
                 interpreter = 'python' if test_file.endswith('.py') else 'bash'
                 test = {'file': test_file,
                         'status': status,
@@ -136,7 +139,7 @@ def run_tests(package, tests):
     # Collect test scripts in package and find the ones that are included
     in_dir = os.path.join(opt.packages_dir, package)
 
-    include_tests = [test for test in tests if test['status'] != 'Skip']
+    include_tests = [test for test in tests if test['status'] != '----']
     skipping = '' if include_tests else ': skipping - no included tests'
     box_output(['package {}{}'.format(package, skipping)])
 
@@ -170,7 +173,7 @@ def run_tests(package, tests):
                 # Test process returned a non-zero status => Fail
                 test['status'] = 'FAIL'
             else:
-                test['status'] = 'Pass'
+                test['status'] = 'pass'
 
     box_output(['{} Test Summary'.format(package)] +
                ['{:20s} {}'.format(test['file'], test['status']) for test in tests])


### PR DESCRIPTION
Working test of archive creation with caveats:
- Uses a hacked version of eng archive `update_archive.py`.  This might be useful later anyway.
- Does not create a derive parameter content type
- 5min and daily stats fail for orbitephem0, need to investigate.